### PR TITLE
removed hard-coded values for service, deployment, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ kubeconfig
 .tmp/
 
 # Build artifacts
-/openshift-cluster-monitor
+bin/


### PR DESCRIPTION
The current implementation uses the metricsource crd to pull in new metrics. This is PR is designed to remove those hard-coded reconciliation values.