### PR TITLE
fixed group-subject RBAC invalidation, email canonicalization, and group-resolution caching

### DIFF
--- a/docs/concepts/policy-evaluation.md
+++ b/docs/concepts/policy-evaluation.md
@@ -441,22 +441,25 @@ cache_key = f"{username}:{','.join(sorted(groups))}"
 
 Caches are invalidated when:
 
-1. **Policy created/updated/deleted** - All affected users, groups, and service accounts have their caches cleared
+1. **Policy created/updated/deleted** - All affected users, groups, and service accounts have their caches cleared. On update, the previous compilation is diffed against the new one and the *union* of old and new subjects is invalidated, so identities dropped from a policy lose their stale "allow" decisions and identities newly named in a policy lose their stale "deny" decisions in the same store call.
 2. **Manual clear** - Via `POST /api/v1/auth/cache/clear`
 
-Invalidation uses Redis SCAN to find affected keys:
+Invalidation uses Redis SCAN to find affected keys.
+
+**User and service-account paths** match by prefix:
 
 ```python
 patterns = [
     f"policy:eval:{user}:*",
-    f"policy:eval:*:group:{group}:*",
     f"policy:eval:{service_account}:*",
     f"rbac:decision:{user}:*",   # Standard decision cache
     f"rbac:custom:{user}:*",     # Custom resource decision cache
 ]
 ```
 
-> **Note:** Redis glob metacharacters (`*`, `?`, `[`, `]`) in usernames are escaped before constructing SCAN patterns to prevent unintended cache key matching.
+**Group path** walks the entire `rbac:decision:*` and `rbac:custom:*` keyspaces and parses the groups CSV segment of each cache key (the `Principal.CacheKey()` format is `{username}:{sorted_groups_csv}`); any cached decision whose groups CSV contains a changed group is deleted. This is the truth source — there is no separate `group:members:*` index to keep in sync, which means group-targeted policy changes always invalidate accurately, regardless of whether affected users have authenticated recently.
+
+> **Note:** Redis glob metacharacters (`*`, `?`, `[`, `]`) in usernames are escaped before constructing user-prefix SCAN patterns to prevent unintended cache key matching.
 
 ## Performance Considerations
 

--- a/docs/concepts/rbac-model.md
+++ b/docs/concepts/rbac-model.md
@@ -60,6 +60,8 @@ The entity making a request. Contains:
 
 Principals are extracted from OAuth proxy headers or Kubernetes authentication.
 
+`username` is canonicalized to the OpenShift `User.metadata.name` whenever a matching `User` CR can be resolved — looked up first by the value of `X-Forwarded-User`, then (when that 404s) by `X-Forwarded-Email`. This is necessary because `openshift/oauth-proxy` stores the user's email in the session cookie and decodes it by splitting on `@`, so `X-Forwarded-User` ends up as the local-part of the email while the actual OpenShift identity is the full email. The fallback ensures policies that name the OpenShift identity (typically the email) match consistently. Service accounts (`system:serviceaccount:…`) are never canonicalized.
+
 ### Resource
 
 The object being accessed:
@@ -408,7 +410,7 @@ The RBAC engine supports optional decision caching:
 
 Cache invalidation occurs when:
 
-1. A policy is created, updated, or deleted — clears `policy:eval:*`, `rbac:decision:*`, and `rbac:custom:*` for affected users/groups
+1. A policy is created, updated, or deleted — clears `policy:eval:*`, `rbac:decision:*`, and `rbac:custom:*` for affected users/groups. Group invalidation is performed by scanning the decision keyspace and matching the groups CSV embedded in the cache key (see [Cache Invalidation](policy-evaluation.md#cache-invalidation) for details). Updates diff against the previous compilation so identities removed from a policy lose their stale "allow" decisions in the same store call.
 2. Manual cache clear via `POST /api/v1/auth/cache/clear` — clears both `rbac:decision:*` and `rbac:custom:*`
 
 ## Related Documentation

--- a/docs/contributing/api.md
+++ b/docs/contributing/api.md
@@ -83,6 +83,7 @@ internal/store/
 | `OAUTH_HEADER_EMAIL` | X-Forwarded-Email | Email header |
 | `ENVIRONMENT` | production | development/production |
 | `RBAC_CACHE_TTL` | 0 | Cache TTL seconds (0=disabled) |
+| `GROUP_CACHE_TTL` | 60 | In-memory cache TTL for `resolveGroups` results — coalesces parallel page-load requests so a single dashboard load hits the OpenShift API at most once per principal. 0 disables. |
 | `SWAGGER_ENABLED` | false | Enable Swagger UI at `/api/v1/swagger/` |
 | `SWAGGER_HOST` | _(empty)_ | Override Swagger API host (empty = use browser URL) |
 

--- a/docs/contributing/policy-controller.md
+++ b/docs/contributing/policy-controller.md
@@ -101,7 +101,7 @@ The policy controller is registered in `cmd/manager/main.go` alongside the other
 1. MonitorAccessPolicy created/updated (generation change predicate filters status-only updates)
 2. `Reconcile()` fetches the CRD
 3. `Compiler.Compile()` validates spec and produces a `CompiledPolicy`
-4. `RedisClient.StorePolicy()` stores the compiled policy + creates all indexes
+4. `RedisClient.StorePolicy()` stores the compiled policy + creates all indexes. On update, it reads the previously-stored compilation and diffs subjects (users, groups, service accounts) and custom resource types; entries dropped in the new revision are removed from their indexes in the same pipeline, and the `policies:enabled` / `policies:effect:{allow|deny}` memberships are reconciled to the new policy state.
 5. `ValidateCompiledPolicy()` checks lifecycle (notBefore/notAfter/enabled)
 6. CRD status and Redis status both updated
 7. `PublishPolicyEvent()` notifies subscribers
@@ -134,8 +134,6 @@ policies:enabled                             # Only enabled policies (set)
 policies:by:priority                         # All policies by priority (zset)
 policies:effect:{allow|deny}                 # Policies by effect (set)
 policy:eval:{identity}:{cluster}             # Evaluation cache
-user:groups:{username}                       # User's group membership
-group:members:{group}                        # Group's members
 user:permissions:{user}                      # User permission cache
 ```
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -22,6 +22,7 @@ type APIConfig struct {
 	Environment       string
 	EnableDevAuth     bool // Explicit flag to enable dev-mode auth bypass
 	RBACCacheTTL      int
+	GroupCacheTTL     int // Seconds to cache resolveGroups results; 0 disables.
 	SwaggerEnabled    bool
 	SwaggerHost       string
 }
@@ -45,6 +46,7 @@ func LoadAPIConfig() *APIConfig {
 		Environment:       envStr("ENVIRONMENT", "production"),
 		EnableDevAuth:     envBool("ENABLE_DEV_AUTH", false),
 		RBACCacheTTL:      envInt("RBAC_CACHE_TTL", 0),
+		GroupCacheTTL:     envInt("GROUP_CACHE_TTL", 60),
 		SwaggerEnabled:    envBool("SWAGGER_ENABLED", false),
 		SwaggerHost:       envStr("SWAGGER_HOST", ""),
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/clusterpulse/cluster-controller/internal/rbac"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -29,6 +32,7 @@ func GetPrincipal(r *http.Request) *rbac.Principal {
 // AuthMiddleware creates an authentication middleware using OAuth proxy headers.
 func AuthMiddleware(cfg *APIConfig) func(http.Handler) http.Handler {
 	dynClient := initDynamicClient()
+	cache := newGroupCache(time.Duration(cfg.GroupCacheTTL) * time.Second)
 
 	// Log a prominent warning if running in dev mode.
 	if cfg.IsDevelopment() && !cfg.OAuthProxyEnabled {
@@ -63,10 +67,10 @@ func AuthMiddleware(cfg *APIConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			groups := resolveGroups(r.Context(), dynClient, username, cfg.IsDevelopment())
+			canonical, groups := resolveGroupsCached(r.Context(), cache, dynClient, username, email, cfg.IsDevelopment())
 
 			principal := &rbac.Principal{
-				Username:         username,
+				Username:         canonical,
 				Email:            email,
 				Groups:           groups,
 				IsServiceAccount: strings.HasPrefix(username, "system:serviceaccount:"),
@@ -82,6 +86,7 @@ func AuthMiddleware(cfg *APIConfig) func(http.Handler) http.Handler {
 // instead of returning 401 when no user header is present.
 func OptionalAuthMiddleware(cfg *APIConfig) func(http.Handler) http.Handler {
 	dynClient := initDynamicClient()
+	cache := newGroupCache(time.Duration(cfg.GroupCacheTTL) * time.Second)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -106,9 +111,9 @@ func OptionalAuthMiddleware(cfg *APIConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			groups := resolveGroups(r.Context(), dynClient, username, cfg.IsDevelopment())
+			canonical, groups := resolveGroupsCached(r.Context(), cache, dynClient, username, email, cfg.IsDevelopment())
 			principal := &rbac.Principal{
-				Username:         username,
+				Username:         canonical,
 				Email:            email,
 				Groups:           groups,
 				IsServiceAccount: strings.HasPrefix(username, "system:serviceaccount:"),
@@ -130,13 +135,44 @@ func SecurityHeaders(next http.Handler) http.Handler {
 	})
 }
 
-// resolveGroups resolves user groups from OpenShift User/Group resources.
-func resolveGroups(ctx context.Context, dynClient dynamic.Interface, username string, isDev bool) []string {
+// resolveGroups resolves the canonical OpenShift principal identity and its
+// group memberships. It returns (canonicalUsername, groups).
+//
+// Background: openshift/oauth-proxy serializes its session cookie with the
+// user's email as the first field, then decodes it by splitting on "@" and
+// keeping only the local part as session.User. The result is that
+// X-Forwarded-User is the local-part of the email, while X-Forwarded-Email
+// is the full email — and the OpenShift User CR's metadata.name is the full
+// email. Looking up User by X-Forwarded-User therefore 404s. We retry the
+// lookup with the email, and if that resolves a real User CR we canonicalize
+// the principal username to that name so the rest of the API (policies,
+// cache keys, Group.users[] matching) consistently uses the OpenShift
+// identity.
+//
+// Service accounts (`system:serviceaccount:...`) are never canonicalized.
+//
+// Emits a per-request INFO log of the resolved groups so misconfigured
+// group resolution (missing User CR, missing RBAC on user.openshift.io
+// resources, broken group sync) is visible in logs.
+func resolveGroups(ctx context.Context, dynClient dynamic.Interface, username, email string, isDev bool) (string, []string) {
 	if dynClient == nil {
 		if isDev {
-			return []string{"developers", "cluster-viewers"}
+			groups := []string{"developers", "cluster-viewers"}
+			logResolvedGroups(username, groups, "dev-fallback (no dynamic client)")
+			return username, groups
 		}
-		return nil
+		logResolvedGroups(username, nil, "no dynamic client")
+		return username, nil
+	}
+
+	// Build the list of identifiers to try, in order. Username first (matches
+	// session.User). Email second when it differs (matches the canonical
+	// OpenShift User.metadata.name when the OAuth IDP mappingMethod is email).
+	// Service accounts always carry a "system:serviceaccount:..." username and
+	// are never canonicalized, so don't fall back to email for them.
+	candidates := []string{username}
+	if email != "" && email != username && !strings.HasPrefix(username, "system:serviceaccount:") {
+		candidates = append(candidates, email)
 	}
 
 	userGVR := schema.GroupVersionResource{
@@ -144,54 +180,207 @@ func resolveGroups(ctx context.Context, dynClient dynamic.Interface, username st
 		Version:  "v1",
 		Resource: "users",
 	}
-
-	// Try to get groups from User resource
-	user, err := dynClient.Resource(userGVR).Get(ctx, username, metav1.GetOptions{})
-	if err == nil {
-		if groups, ok := user.Object["groups"].([]any); ok {
-			result := make([]string, 0, len(groups))
-			for _, g := range groups {
-				if s, ok := g.(string); ok {
-					result = append(result, s)
-				}
-			}
-			if len(result) > 0 {
-				return result
-			}
-		}
-	}
-
-	// Fallback: iterate Group resources
 	groupGVR := schema.GroupVersionResource{
 		Group:    "user.openshift.io",
 		Version:  "v1",
 		Resource: "groups",
 	}
 
-	groupList, err := dynClient.Resource(groupGVR).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		logrus.WithError(err).Debug("Failed to list OpenShift groups")
-		if isDev {
-			return []string{"developers", "cluster-viewers"}
+	// Step 1: try each candidate against the User CR until one resolves.
+	// If the User exists with non-empty groups, return immediately with that
+	// identity as canonical.
+	var canonical string
+	var userLookupErr error
+	for _, ident := range candidates {
+		user, err := dynClient.Resource(userGVR).Get(ctx, ident, metav1.GetOptions{})
+		if err != nil {
+			userLookupErr = err
+			continue
 		}
-		return nil
+		canonical = ident
+		groups := extractUserGroups(user)
+		if len(groups) > 0 {
+			logResolvedGroups(canonical, groups, "user.openshift.io User.groups (canonicalized to "+canonical+")")
+			return canonical, groups
+		}
+		// User CR exists but its .groups is empty/null. Fall through to the
+		// Group list scan — but remember we have a canonical identity now.
+		break
+	}
+	if canonical == "" && userLookupErr != nil {
+		logrus.WithError(userLookupErr).Warnf("resolveGroups: no user.openshift.io User CR found for any of %v; falling back to Group list", candidates)
 	}
 
+	// Step 2: scan Groups for membership. Try the canonical identifier first
+	// if we found a User CR, otherwise try each candidate.
+	groupList, err := dynClient.Resource(groupGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logrus.WithError(err).Warnf("resolveGroups: failed to list OpenShift Groups for user %q", username)
+		if isDev {
+			groups := []string{"developers", "cluster-viewers"}
+			logResolvedGroups(username, groups, "dev-fallback (Group list failed)")
+			return username, groups
+		}
+		logResolvedGroups(username, nil, "Group list failed")
+		return username, nil
+	}
+
+	scanOrder := candidates
+	if canonical != "" {
+		// Prefer the canonical identity first; keep the others as backup so
+		// admins who listed the short username in Group.users[] still match.
+		scanOrder = append([]string{canonical}, diffWithout(candidates, canonical)...)
+	}
+	for _, ident := range scanOrder {
+		if groups := findGroupsContainingUser(groupList.Items, ident); len(groups) > 0 {
+			logResolvedGroups(ident, groups, "Group list scan (canonicalized to "+ident+")")
+			return ident, groups
+		}
+	}
+
+	// No groups found anywhere. Return the canonical identity if we have one
+	// (so policies that name the OpenShift identity still match), else fall
+	// back to the original username.
+	identity := username
+	if canonical != "" {
+		identity = canonical
+	}
+	logResolvedGroups(identity, nil, "no Group membership found")
+	return identity, nil
+}
+
+// extractUserGroups pulls the .groups []string field from an OpenShift User CR.
+func extractUserGroups(user *unstructured.Unstructured) []string {
+	groups, ok := user.Object["groups"].([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if s, ok := g.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// findGroupsContainingUser returns the names of Groups whose users[] array
+// contains exactly `ident`.
+func findGroupsContainingUser(items []unstructured.Unstructured, ident string) []string {
 	var groups []string
-	for _, g := range groupList.Items {
+	for _, g := range items {
 		users, ok := g.Object["users"].([]any)
 		if !ok {
 			continue
 		}
 		for _, u := range users {
-			if s, ok := u.(string); ok && s == username {
+			if s, ok := u.(string); ok && s == ident {
 				groups = append(groups, g.GetName())
 				break
 			}
 		}
 	}
-
 	return groups
+}
+
+// diffWithout returns a copy of `xs` with `drop` removed (first occurrence).
+func diffWithout(xs []string, drop string) []string {
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if x != drop {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// logResolvedGroups emits a structured INFO log of the groups attached to
+// a Principal at request time. Crucial signal when diagnosing RBAC outages.
+func logResolvedGroups(username string, groups []string, source string) {
+	logrus.WithFields(logrus.Fields{
+		"user":   username,
+		"groups": groups,
+		"source": source,
+	}).Info("resolved principal groups")
+}
+
+// groupCacheEntry holds a single cached resolveGroups result.
+type groupCacheEntry struct {
+	canonical string
+	groups    []string
+	expiresAt time.Time
+}
+
+// groupCache is a small in-memory TTL cache that coalesces duplicate
+// resolveGroups calls during a single page load. Per-pod, mutex-protected.
+// Caches both positive and "no groups" results so absent users don't keep
+// hitting the OpenShift API every request. TTL <= 0 disables caching.
+type groupCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]groupCacheEntry
+}
+
+func newGroupCache(ttl time.Duration) *groupCache {
+	if ttl <= 0 {
+		return nil
+	}
+	return &groupCache{
+		ttl:     ttl,
+		entries: make(map[string]groupCacheEntry),
+	}
+}
+
+// groupCacheKey returns the cache key for a (username, email) pair. We embed
+// a NUL separator so usernames containing the email value can't collide with
+// neighbouring keys.
+func groupCacheKey(username, email string) string {
+	return username + "\x00" + email
+}
+
+func (c *groupCache) get(username, email string) (string, []string, bool) {
+	if c == nil {
+		return "", nil, false
+	}
+	key := groupCacheKey(username, email)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.entries[key]
+	if !ok {
+		return "", nil, false
+	}
+	if time.Now().After(v.expiresAt) {
+		delete(c.entries, key)
+		return "", nil, false
+	}
+	return v.canonical, v.groups, true
+}
+
+func (c *groupCache) put(username, email, canonical string, groups []string) {
+	if c == nil {
+		return
+	}
+	key := groupCacheKey(username, email)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = groupCacheEntry{
+		canonical: canonical,
+		groups:    groups,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// resolveGroupsCached wraps resolveGroups with a short-TTL cache. The cache
+// is keyed by the raw (username, email) headers — not by the canonicalized
+// identity — so a single page load of N parallel requests with the same
+// auth headers hits OpenShift at most once.
+func resolveGroupsCached(ctx context.Context, cache *groupCache, dynClient dynamic.Interface, username, email string, isDev bool) (string, []string) {
+	if canonical, groups, ok := cache.get(username, email); ok {
+		return canonical, groups
+	}
+	canonical, groups := resolveGroups(ctx, dynClient, username, email, isDev)
+	cache.put(username, email, canonical, groups)
+	return canonical, groups
 }
 
 func initDynamicClient() dynamic.Interface {

--- a/internal/api/middleware_resolvegroups_test.go
+++ b/internal/api/middleware_resolvegroups_test.go
@@ -1,0 +1,368 @@
+package api
+
+import (
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// makeUser constructs a fake user.openshift.io/v1 User CR with the given name
+// and groups list. A nil groups slice produces a User CR with `groups: null`
+// (which is what oauth-server-managed Users typically look like before group sync).
+func makeUser(name string, groups []string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("user.openshift.io/v1")
+	u.SetKind("User")
+	u.SetName(name)
+	if groups != nil {
+		raw := make([]any, len(groups))
+		for i, g := range groups {
+			raw[i] = g
+		}
+		u.Object["groups"] = raw
+	} else {
+		u.Object["groups"] = nil
+	}
+	return u
+}
+
+// makeGroup constructs a fake user.openshift.io/v1 Group with the given name
+// and users list.
+func makeGroup(name string, users []string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("user.openshift.io/v1")
+	u.SetKind("Group")
+	u.SetName(name)
+	raw := make([]any, len(users))
+	for i, x := range users {
+		raw[i] = x
+	}
+	u.Object["users"] = raw
+	return u
+}
+
+// newFakeDynClient returns a fake dynamic client preloaded with the supplied
+// User and Group CRs. The List kinds for both resources are registered so
+// resolveGroups' Group list-scan path works.
+func newFakeDynClient(objs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	userGVR := schema.GroupVersionResource{Group: "user.openshift.io", Version: "v1", Resource: "users"}
+	groupGVR := schema.GroupVersionResource{Group: "user.openshift.io", Version: "v1", Resource: "groups"}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		userGVR:  "UserList",
+		groupGVR: "GroupList",
+	}
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		runtimeObjs = append(runtimeObjs, o)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, runtimeObjs...)
+}
+
+func TestResolveGroups_UsernameHitsUserCR(t *testing.T) {
+	dyn := newFakeDynClient(
+		makeUser("alice", []string{"team-a", "team-b"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "alice", "alice@example.com", false)
+
+	if canonical != "alice" {
+		t.Errorf("canonical = %q, want %q", canonical, "alice")
+	}
+	if !slices.Equal(groups, []string{"team-a", "team-b"}) {
+		t.Errorf("groups = %v, want [team-a team-b]", groups)
+	}
+}
+
+func TestResolveGroups_EmailFallbackHitsUserCR(t *testing.T) {
+	// Simulates the openshift/oauth-proxy session cookie bug: X-Forwarded-User
+	// is the local-part of the email; the User CR's metadata.name is the full email.
+	dyn := newFakeDynClient(
+		makeUser("user1@gmail.com", []string{"engineering"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1@gmail.com" {
+		t.Errorf("canonical = %q, want %q (should canonicalize to the User CR's name)", canonical, "user1@gmail.com")
+	}
+	if !slices.Equal(groups, []string{"engineering"}) {
+		t.Errorf("groups = %v, want [engineering]", groups)
+	}
+}
+
+func TestResolveGroups_UserCRGroupsNullFallsBackToGroupListByCanonical(t *testing.T) {
+	// Matches the bug report: User CR exists (named with the email) but its
+	// groups field is null. The Group resource lists the canonical email
+	// as a member. resolveGroups must canonicalize AND find the group via
+	// the Group list scan.
+	dyn := newFakeDynClient(
+		makeUser("user1@gmail.com", nil),
+		makeGroup("engineering", []string{"user1@gmail.com"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1@gmail.com" {
+		t.Errorf("canonical = %q, want %q", canonical, "user1@gmail.com")
+	}
+	if !slices.Equal(groups, []string{"engineering"}) {
+		t.Errorf("groups = %v, want [engineering]", groups)
+	}
+}
+
+func TestResolveGroups_GroupListContainsShortUsername(t *testing.T) {
+	// No User CRs exist for either identifier. An admin added the short
+	// username (the only thing they saw before this fix) to a Group.users[].
+	// resolveGroups should still find it via the scan, preserving back-compat.
+	dyn := newFakeDynClient(
+		makeGroup("legacy", []string{"user1"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1" {
+		t.Errorf("canonical = %q, want %q (should fall back to original when no User CR exists)", canonical, "user1")
+	}
+	if !slices.Equal(groups, []string{"legacy"}) {
+		t.Errorf("groups = %v, want [legacy]", groups)
+	}
+}
+
+func TestResolveGroups_GroupListContainsEmailIdentity(t *testing.T) {
+	// No User CR for either form, but Group.users[] contains the email.
+	dyn := newFakeDynClient(
+		makeGroup("engineering", []string{"user1@gmail.com"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1@gmail.com" {
+		t.Errorf("canonical = %q, want %q", canonical, "user1@gmail.com")
+	}
+	if !slices.Equal(groups, []string{"engineering"}) {
+		t.Errorf("groups = %v, want [engineering]", groups)
+	}
+}
+
+func TestResolveGroups_ServiceAccountNotCanonicalized(t *testing.T) {
+	// Service accounts must not be canonicalized to an email even if one is
+	// somehow forwarded; their identifier is the SA path string.
+	dyn := newFakeDynClient(
+		// Add an unrelated User CR with email-as-name; resolveGroups must NOT
+		// retry the SA lookup against this email.
+		makeUser("ops@example.com", []string{"engineering"}),
+		makeGroup("legacy", []string{"system:serviceaccount:ns:sa1"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "system:serviceaccount:ns:sa1", "ops@example.com", false)
+
+	if canonical != "system:serviceaccount:ns:sa1" {
+		t.Errorf("canonical = %q, want %q (SAs must not be canonicalized to an email)", canonical, "system:serviceaccount:ns:sa1")
+	}
+	if !slices.Equal(groups, []string{"legacy"}) {
+		t.Errorf("groups = %v, want [legacy]", groups)
+	}
+}
+
+func TestResolveGroups_NoMatchesReturnsEmpty(t *testing.T) {
+	dyn := newFakeDynClient()
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1" {
+		t.Errorf("canonical = %q, want %q (no match should fall back to original)", canonical, "user1")
+	}
+	if groups != nil {
+		t.Errorf("groups = %v, want nil", groups)
+	}
+}
+
+func TestResolveGroups_NilDynClient_DevFallback(t *testing.T) {
+	canonical, groups := resolveGroups(t.Context(), nil, "user1", "user1@gmail.com", true)
+
+	if canonical != "user1" {
+		t.Errorf("canonical = %q, want %q", canonical, "user1")
+	}
+	if !slices.Equal(groups, []string{"developers", "cluster-viewers"}) {
+		t.Errorf("groups = %v, want dev fallback set", groups)
+	}
+}
+
+func TestResolveGroups_NilDynClient_NoDev(t *testing.T) {
+	canonical, groups := resolveGroups(t.Context(), nil, "user1", "user1@gmail.com", false)
+
+	if canonical != "user1" {
+		t.Errorf("canonical = %q, want %q", canonical, "user1")
+	}
+	if groups != nil {
+		t.Errorf("groups = %v, want nil", groups)
+	}
+}
+
+func TestResolveGroups_EmptyEmailDoesNotPanic(t *testing.T) {
+	dyn := newFakeDynClient(
+		makeGroup("team", []string{"user1"}),
+	)
+
+	canonical, groups := resolveGroups(t.Context(), dyn, "user1", "", false)
+	if canonical != "user1" {
+		t.Errorf("canonical = %q, want %q", canonical, "user1")
+	}
+	if !slices.Equal(groups, []string{"team"}) {
+		t.Errorf("groups = %v, want [team]", groups)
+	}
+}
+
+// countingDynClient wraps a fake dynamic client to count API calls per resource.
+// Used to assert that resolveGroupsCached coalesces repeat lookups.
+type countingDynClient struct {
+	dynamic.Interface
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (c *countingDynClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	c.mu.Lock()
+	c.calls[gvr.Resource]++
+	c.mu.Unlock()
+	return c.Interface.Resource(gvr)
+}
+
+func (c *countingDynClient) count(resource string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls[resource]
+}
+
+func newCountingDyn(objs ...*unstructured.Unstructured) *countingDynClient {
+	return &countingDynClient{
+		Interface: newFakeDynClient(objs...),
+		calls:     map[string]int{},
+	}
+}
+
+func TestResolveGroupsCached_CoalescesRepeatedCalls(t *testing.T) {
+	dyn := newCountingDyn(
+		makeUser("user1@gmail.com", nil),
+		makeGroup("engineering", []string{"user1@gmail.com"}),
+	)
+	cache := newGroupCache(60 * time.Second)
+
+	for i := range 4 {
+		canonical, groups := resolveGroupsCached(t.Context(), cache, dyn, "user1", "user1@gmail.com", false)
+		if canonical != "user1@gmail.com" {
+			t.Fatalf("iter %d: canonical = %q, want user1@gmail.com", i, canonical)
+		}
+		if !slices.Equal(groups, []string{"engineering"}) {
+			t.Fatalf("iter %d: groups = %v, want [engineering]", i, groups)
+		}
+	}
+
+	// First call: looks up "user1" (404), then "user1@gmail.com" (hit, but groups null),
+	// then lists groups once. So users=2, groups=1. Cached calls must add zero.
+	if got := dyn.count("users"); got != 2 {
+		t.Errorf("users API calls = %d, want 2 (only the first uncached request)", got)
+	}
+	if got := dyn.count("groups"); got != 1 {
+		t.Errorf("groups API calls = %d, want 1", got)
+	}
+}
+
+func TestResolveGroupsCached_CachesEmptyResult(t *testing.T) {
+	dyn := newCountingDyn() // no Users, no Groups
+	cache := newGroupCache(60 * time.Second)
+
+	for range 3 {
+		canonical, groups := resolveGroupsCached(t.Context(), cache, dyn, "ghost", "ghost@example.com", false)
+		if canonical != "ghost" {
+			t.Fatalf("canonical = %q, want ghost", canonical)
+		}
+		if groups != nil {
+			t.Fatalf("groups = %v, want nil", groups)
+		}
+	}
+
+	if got := dyn.count("users"); got != 2 {
+		t.Errorf("users API calls = %d, want 2 (one per candidate, only on first call)", got)
+	}
+	if got := dyn.count("groups"); got != 1 {
+		t.Errorf("groups API calls = %d, want 1", got)
+	}
+}
+
+func TestResolveGroupsCached_DistinctPrincipalsBypassEachOther(t *testing.T) {
+	dyn := newCountingDyn(
+		makeUser("alice@example.com", []string{"team-a"}),
+		makeUser("bob@example.com", []string{"team-b"}),
+	)
+	cache := newGroupCache(60 * time.Second)
+
+	_, gA := resolveGroupsCached(t.Context(), cache, dyn, "alice", "alice@example.com", false)
+	_, gB := resolveGroupsCached(t.Context(), cache, dyn, "bob", "bob@example.com", false)
+	_, gA2 := resolveGroupsCached(t.Context(), cache, dyn, "alice", "alice@example.com", false)
+
+	if !slices.Equal(gA, []string{"team-a"}) || !slices.Equal(gA2, []string{"team-a"}) {
+		t.Errorf("alice groups = %v / %v", gA, gA2)
+	}
+	if !slices.Equal(gB, []string{"team-b"}) {
+		t.Errorf("bob groups = %v", gB)
+	}
+
+	// alice 1st call: 2 user lookups (404, hit). bob 1st call: same. alice 2nd: cached.
+	if got := dyn.count("users"); got != 4 {
+		t.Errorf("users API calls = %d, want 4", got)
+	}
+}
+
+func TestResolveGroupsCached_TTLExpiry(t *testing.T) {
+	dyn := newCountingDyn(
+		makeUser("user1@gmail.com", []string{"engineering"}),
+	)
+	cache := newGroupCache(60 * time.Second)
+
+	resolveGroupsCached(t.Context(), cache, dyn, "user1", "user1@gmail.com", false)
+	if got := dyn.count("users"); got != 2 {
+		t.Fatalf("after first call: users = %d, want 2", got)
+	}
+
+	// Force expiry by mutating the entry's expiresAt.
+	cache.mu.Lock()
+	for k, v := range cache.entries {
+		v.expiresAt = time.Now().Add(-1 * time.Second)
+		cache.entries[k] = v
+	}
+	cache.mu.Unlock()
+
+	resolveGroupsCached(t.Context(), cache, dyn, "user1", "user1@gmail.com", false)
+	if got := dyn.count("users"); got != 4 {
+		t.Errorf("after expiry: users = %d, want 4 (cache miss should re-query)", got)
+	}
+}
+
+func TestResolveGroupsCached_NilCacheBypasses(t *testing.T) {
+	dyn := newCountingDyn(
+		makeUser("alice", []string{"team-a"}),
+	)
+
+	// ttl <= 0 → newGroupCache returns nil; wrapper must not panic and must
+	// fall through to resolveGroups on every call.
+	cache := newGroupCache(0)
+	if cache != nil {
+		t.Fatalf("newGroupCache(0) should return nil")
+	}
+
+	for range 3 {
+		resolveGroupsCached(t.Context(), cache, dyn, "alice", "", false)
+	}
+	if got := dyn.count("users"); got != 3 {
+		t.Errorf("users API calls = %d, want 3 (every call uncached)", got)
+	}
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -49,14 +49,20 @@ func TestSecurityHeaders(t *testing.T) {
 }
 
 func TestResolveGroups_NilClient_Dev(t *testing.T) {
-	groups := resolveGroups(t.Context(), nil, "user", true)
+	canonical, groups := resolveGroups(t.Context(), nil, "user", "", true)
+	if canonical != "user" {
+		t.Errorf("canonical = %q, want %q", canonical, "user")
+	}
 	if len(groups) != 2 || groups[0] != "developers" {
 		t.Errorf("dev mode nil client should return dev groups, got %v", groups)
 	}
 }
 
 func TestResolveGroups_NilClient_Prod(t *testing.T) {
-	groups := resolveGroups(t.Context(), nil, "user", false)
+	canonical, groups := resolveGroups(t.Context(), nil, "user", "", false)
+	if canonical != "user" {
+		t.Errorf("canonical = %q, want %q", canonical, "user")
+	}
 	if groups != nil {
 		t.Errorf("prod mode nil client should return nil, got %v", groups)
 	}

--- a/internal/store/policy_storage.go
+++ b/internal/store/policy_storage.go
@@ -14,13 +14,12 @@ import (
 
 // Policy Redis key patterns (must match Python exactly)
 const (
-	keyPolicy             = "policy:%s:%s"           // namespace:name
-	keyPolicyUser         = "policy:user:%s"         // user
-	keyPolicyGroup        = "policy:group:%s"        // group
-	keyPolicySA           = "policy:sa:%s"           // sa
-	keyPolicyCustomType   = "policy:customtype:%s"   // resource_type
-	keyUserPermissions    = "user:permissions:%s"    // user
-	keyGroupMembers       = "group:members:%s"       // group
+	keyPolicy             = "policy:%s:%s"         // namespace:name
+	keyPolicyUser         = "policy:user:%s"       // user
+	keyPolicyGroup        = "policy:group:%s"      // group
+	keyPolicySA           = "policy:sa:%s"         // sa
+	keyPolicyCustomType   = "policy:customtype:%s" // resource_type
+	keyUserPermissions    = "user:permissions:%s"  // user
 	keyPoliciesAll        = "policies:all"
 	keyPoliciesEnabled    = "policies:enabled"
 	keyPoliciesByPriority = "policies:by:priority"
@@ -28,7 +27,14 @@ const (
 	policyScanBatchSize = 100
 )
 
-// StorePolicy stores a compiled policy in Redis with all indexes
+// StorePolicy stores a compiled policy in Redis with all indexes.
+//
+// On UPDATE, it diffs against the previously-stored compilation and cleans
+// stale index entries for subjects that were removed in this revision. The
+// effective set of subjects for indexing is empty when the policy is disabled
+// (matching the SAdd guards below), so toggling Enabled correctly removes or
+// adds subjects from the indexes. Caches are invalidated for the union of old
+// and new subjects so removed identities lose stale "allow" decisions.
 func (c *Client) StorePolicy(ctx context.Context, policy *types.CompiledPolicy) error {
 	policyKey := fmt.Sprintf(keyPolicy, policy.Namespace, policy.PolicyName)
 
@@ -36,6 +42,9 @@ func (c *Client) StorePolicy(ctx context.Context, policy *types.CompiledPolicy) 
 	if err != nil {
 		return fmt.Errorf("failed to marshal policy: %w", err)
 	}
+
+	// Read the previous compilation (if any) so we can clean up stale indexes.
+	oldPolicy := c.readPreviousPolicy(ctx, policyKey)
 
 	pipe := c.client.Pipeline()
 
@@ -52,36 +61,50 @@ func (c *Client) StorePolicy(ctx context.Context, policy *types.CompiledPolicy) 
 		return &goredis.Z{Score: float64(priority), Member: member}
 	}
 
-	// Index by users
-	for _, user := range policy.Users {
-		if policy.Enabled {
+	// Diff-driven index cleanup: drop subjects (and custom resource types) that
+	// were indexed under the previous compilation but are no longer present, or
+	// drop all of them if the policy is being disabled.
+	oldUsers, oldGroups, oldSAs, oldTypes := indexedSubjects(oldPolicy)
+	newUsers, newGroups, newSAs, newTypes := indexedSubjects(policy)
+	for _, u := range diffStrings(oldUsers, newUsers) {
+		k := fmt.Sprintf(keyPolicyUser, u)
+		pipe.SRem(ctx, k, policyKey)
+		pipe.ZRem(ctx, k+":sorted", policyKey)
+	}
+	for _, g := range diffStrings(oldGroups, newGroups) {
+		k := fmt.Sprintf(keyPolicyGroup, g)
+		pipe.SRem(ctx, k, policyKey)
+		pipe.ZRem(ctx, k+":sorted", policyKey)
+	}
+	for _, sa := range diffStrings(oldSAs, newSAs) {
+		k := fmt.Sprintf(keyPolicySA, sa)
+		pipe.SRem(ctx, k, policyKey)
+		pipe.ZRem(ctx, k+":sorted", policyKey)
+	}
+	for _, rt := range diffStrings(oldTypes, newTypes) {
+		k := fmt.Sprintf(keyPolicyCustomType, rt)
+		pipe.SRem(ctx, k, policyKey)
+		pipe.ZRem(ctx, k+":sorted", policyKey)
+	}
+
+	// Index by users / groups / SAs / custom resource types (enabled only).
+	if policy.Enabled {
+		for _, user := range policy.Users {
 			userKey := fmt.Sprintf(keyPolicyUser, user)
 			pipe.SAdd(ctx, userKey, policyKey)
 			pipe.ZAdd(ctx, userKey+":sorted", z(policy.Priority, policyKey))
 		}
-	}
-
-	// Index by groups
-	for _, group := range policy.Groups {
-		if policy.Enabled {
+		for _, group := range policy.Groups {
 			groupKey := fmt.Sprintf(keyPolicyGroup, group)
 			pipe.SAdd(ctx, groupKey, policyKey)
 			pipe.ZAdd(ctx, groupKey+":sorted", z(policy.Priority, policyKey))
 		}
-	}
-
-	// Index by service accounts
-	for _, sa := range policy.ServiceAccounts {
-		if policy.Enabled {
+		for _, sa := range policy.ServiceAccounts {
 			saKey := fmt.Sprintf(keyPolicySA, sa)
 			pipe.SAdd(ctx, saKey, policyKey)
 			pipe.ZAdd(ctx, saKey+":sorted", z(policy.Priority, policyKey))
 		}
-	}
-
-	// Index by custom resource types
-	for _, resourceType := range policy.CustomResourceTypes {
-		if policy.Enabled {
+		for _, resourceType := range policy.CustomResourceTypes {
 			typeKey := fmt.Sprintf(keyPolicyCustomType, resourceType)
 			pipe.SAdd(ctx, typeKey, policyKey)
 			pipe.ZAdd(ctx, typeKey+":sorted", z(policy.Priority, policyKey))
@@ -94,19 +117,120 @@ func (c *Client) StorePolicy(ctx context.Context, policy *types.CompiledPolicy) 
 
 	if policy.Enabled {
 		pipe.SAdd(ctx, keyPoliciesEnabled, policyKey)
+	} else {
+		pipe.SRem(ctx, keyPoliciesEnabled, policyKey)
 	}
 
-	pipe.SAdd(ctx, fmt.Sprintf("policies:effect:%s", strings.ToLower(policy.Effect)), policyKey)
+	newEffectKey := fmt.Sprintf("policies:effect:%s", strings.ToLower(policy.Effect))
+	pipe.SAdd(ctx, newEffectKey, policyKey)
+	if oldPolicy != nil && !strings.EqualFold(oldPolicy.Effect, policy.Effect) && oldPolicy.Effect != "" {
+		pipe.SRem(ctx, fmt.Sprintf("policies:effect:%s", strings.ToLower(oldPolicy.Effect)), policyKey)
+	}
 
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to store policy: %w", err)
 	}
 
-	c.InvalidateEvaluationCaches(ctx, policy.Users, policy.Groups, policy.ServiceAccounts)
+	// Invalidate caches for the UNION of old and new subjects: identities that
+	// were removed in this update need stale "allow" decisions cleared, and
+	// identities just granted need stale "deny" decisions cleared.
+	c.InvalidateEvaluationCaches(
+		ctx,
+		unionStrings(oldUsersAll(oldPolicy), policy.Users),
+		unionStrings(oldGroupsAll(oldPolicy), policy.Groups),
+		unionStrings(oldSAsAll(oldPolicy), policy.ServiceAccounts),
+	)
 
 	logrus.Infof("Stored policy %s with %d custom resource types", policyKey, len(policy.CustomResourceTypes))
 	return nil
+}
+
+// readPreviousPolicy fetches the previously-stored compiled policy at policyKey.
+// Returns nil if the policy doesn't exist or can't be unmarshaled.
+func (c *Client) readPreviousPolicy(ctx context.Context, policyKey string) *types.CompiledPolicy {
+	data, err := c.client.HGet(ctx, policyKey, "data").Result()
+	if err != nil {
+		return nil
+	}
+	var p types.CompiledPolicy
+	if err := json.Unmarshal([]byte(data), &p); err != nil {
+		logrus.WithError(err).Warnf("Failed to unmarshal previous policy %s; stale indexes may remain", policyKey)
+		return nil
+	}
+	return &p
+}
+
+// indexedSubjects returns the subject and custom-resource-type slices that
+// are currently expected to be present in the per-subject Redis indexes for
+// the given policy. When the policy is nil or disabled the policy's subjects
+// were never written to indexes, so all returned slices are empty.
+func indexedSubjects(p *types.CompiledPolicy) (users, groups, sas, types []string) {
+	if p == nil || !p.Enabled {
+		return nil, nil, nil, nil
+	}
+	return p.Users, p.Groups, p.ServiceAccounts, p.CustomResourceTypes
+}
+
+// oldUsersAll / oldGroupsAll / oldSAsAll return the raw subject slices from a
+// previous policy regardless of its enabled state. Used for cache invalidation,
+// where we want to clear decisions for *any* identity ever named by the policy.
+func oldUsersAll(p *types.CompiledPolicy) []string {
+	if p == nil {
+		return nil
+	}
+	return p.Users
+}
+
+func oldGroupsAll(p *types.CompiledPolicy) []string {
+	if p == nil {
+		return nil
+	}
+	return p.Groups
+}
+
+func oldSAsAll(p *types.CompiledPolicy) []string {
+	if p == nil {
+		return nil
+	}
+	return p.ServiceAccounts
+}
+
+// diffStrings returns elements present in `a` but not in `b`.
+func diffStrings(a, b []string) []string {
+	if len(a) == 0 {
+		return nil
+	}
+	bset := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		bset[x] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, x := range a {
+		if _, ok := bset[x]; !ok {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// unionStrings returns the set-union of `a` and `b`, deduplicated, order undefined.
+func unionStrings(a, b []string) []string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	s := make(map[string]struct{}, len(a)+len(b))
+	for _, x := range a {
+		s[x] = struct{}{}
+	}
+	for _, x := range b {
+		s[x] = struct{}{}
+	}
+	out := make([]string, 0, len(s))
+	for x := range s {
+		out = append(out, x)
+	}
+	return out
 }
 
 // RemovePolicy removes a policy and all its indexes from Redis
@@ -207,6 +331,13 @@ func (c *Client) UpdatePolicyStatus(ctx context.Context, namespace, name string,
 // InvalidateEvaluationCaches clears evaluation caches for affected identities.
 // Also clears rbac:decision:* and rbac:custom:* caches so stale
 // authorization decisions don't persist after policy changes.
+//
+// Group invalidation walks the RBAC decision keyspace directly rather than
+// consulting a separately-maintained group-membership index: the cache itself
+// is the truth source, so we scan keys and delete those whose groups CSV
+// (encoded in the cache key by Principal.CacheKey) intersects with the
+// changed group set. This costs an O(keyspace) scan, which is acceptable
+// because policy changes are rare.
 func (c *Client) InvalidateEvaluationCaches(ctx context.Context, users, groups, serviceAccounts []string) {
 	count := 0
 	pipe := c.client.Pipeline()
@@ -219,17 +350,11 @@ func (c *Client) InvalidateEvaluationCaches(ctx context.Context, users, groups, 
 		count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("rbac:custom:%s:*", escapeRedisGlobChars(user)))
 	}
 
-	for _, group := range groups {
-		members, err := c.client.SMembers(ctx, fmt.Sprintf(keyGroupMembers, group)).Result()
-		if err == nil {
-			for _, member := range members {
-				count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("policy:eval:%s:*", member))
-				pipe.Del(ctx, fmt.Sprintf(keyUserPermissions, member))
-				count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("rbac:decision:%s:*", escapeRedisGlobChars(member)))
-				count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("rbac:custom:%s:*", escapeRedisGlobChars(member)))
-			}
+	if len(groups) > 0 {
+		count += c.invalidateRBACDecisionsForGroups(ctx, pipe, groups)
+		for _, group := range groups {
+			count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("policy:eval:*:group:%s:*", group))
 		}
-		count += c.scanAndDeletePolicy(ctx, pipe, fmt.Sprintf("policy:eval:*:group:%s:*", group))
 	}
 
 	for _, sa := range serviceAccounts {
@@ -243,6 +368,71 @@ func (c *Client) InvalidateEvaluationCaches(ctx context.Context, users, groups, 
 	}
 
 	logrus.Debugf("Cleared %d evaluation cache entries", count)
+}
+
+// invalidateRBACDecisionsForGroups scans rbac:decision:* and rbac:custom:* keys
+// and queues for deletion any entry whose Principal.CacheKey groups CSV
+// contains one of the changed groups. The cache key format is
+// "rbac:{decision|custom}:{username}:{sorted_groups_csv}:..." where the CSV
+// is comma-joined. We scan each `:`-delimited segment of the suffix and look
+// for any element matching a changed group, which tolerates usernames that
+// themselves contain colons (e.g. service accounts).
+func (c *Client) invalidateRBACDecisionsForGroups(ctx context.Context, pipe goredis.Pipeliner, groups []string) int {
+	changed := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		if g != "" {
+			changed[g] = struct{}{}
+		}
+	}
+	if len(changed) == 0 {
+		return 0
+	}
+
+	count := 0
+	for _, prefix := range []string{"rbac:decision:", "rbac:custom:"} {
+		pattern := prefix + "*"
+		var cursor uint64
+		for {
+			keys, next, err := c.client.Scan(ctx, cursor, pattern, policyScanBatchSize).Result()
+			if err != nil {
+				break
+			}
+			for _, key := range keys {
+				suffix, ok := strings.CutPrefix(key, prefix)
+				if !ok {
+					continue
+				}
+				if cacheKeyMatchesGroup(suffix, changed) {
+					pipe.Del(ctx, key)
+					count++
+				}
+			}
+			cursor = next
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+	return count
+}
+
+// cacheKeyMatchesGroup reports whether any `:`-delimited segment of the
+// supplied cache-key suffix contains a CSV element present in `changed`.
+func cacheKeyMatchesGroup(suffix string, changed map[string]struct{}) bool {
+	for segment := range strings.SplitSeq(suffix, ":") {
+		if segment == "" {
+			continue
+		}
+		for elem := range strings.SplitSeq(segment, ",") {
+			if elem == "" {
+				continue
+			}
+			if _, hit := changed[elem]; hit {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // escapeRedisGlobChars escapes Redis glob metacharacters to prevent pattern injection.

--- a/internal/store/policy_storage_test.go
+++ b/internal/store/policy_storage_test.go
@@ -240,6 +240,226 @@ func TestEscapeRedisGlobChars(t *testing.T) {
 	}
 }
 
+func TestStorePolicy_RemovesStaleSubjectIndexesOnUpdate(t *testing.T) {
+	c, _ := newTestClient(t)
+	ctx := t.Context()
+
+	p := testPolicy()
+	p.Users = []string{"alice", "bob"}
+	p.Groups = []string{"team-a", "team-b"}
+	p.ServiceAccounts = []string{"system:serviceaccount:default:sa1"}
+	p.CustomResourceTypes = []string{"virtualmachines", "routes"}
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-store with bob, team-b, the SA, and "routes" removed.
+	p2 := testPolicy()
+	p2.Users = []string{"alice"}
+	p2.Groups = []string{"team-a"}
+	p2.ServiceAccounts = nil
+	p2.CustomResourceTypes = []string{"virtualmachines"}
+	if err := c.StorePolicy(ctx, p2); err != nil {
+		t.Fatal(err)
+	}
+
+	policyKey := "policy:default:test-policy"
+
+	mustNotIndex := []struct{ key, label string }{
+		{"policy:user:bob", "removed user"},
+		{"policy:user:bob:sorted", "removed user sorted set"},
+		{"policy:group:team-b", "removed group"},
+		{"policy:group:team-b:sorted", "removed group sorted set"},
+		{"policy:sa:system:serviceaccount:default:sa1", "removed SA"},
+		{"policy:customtype:routes", "removed custom resource type"},
+	}
+	for _, k := range mustNotIndex {
+		if isMember, _ := c.client.SIsMember(ctx, k.key, policyKey).Result(); isMember {
+			t.Errorf("policy still indexed under %s (%s)", k.key, k.label)
+		}
+	}
+
+	mustIndex := []string{
+		"policy:user:alice",
+		"policy:group:team-a",
+		"policy:customtype:virtualmachines",
+	}
+	for _, k := range mustIndex {
+		if isMember, _ := c.client.SIsMember(ctx, k, policyKey).Result(); !isMember {
+			t.Errorf("policy missing from preserved index %s", k)
+		}
+	}
+}
+
+func TestStorePolicy_DisablingRemovesSubjectsFromIndexes(t *testing.T) {
+	c, _ := newTestClient(t)
+	ctx := t.Context()
+
+	p := testPolicy()
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	p.Enabled = false
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	policyKey := "policy:default:test-policy"
+	for _, k := range []string{
+		"policy:user:alice",
+		"policy:group:admins",
+		"policy:sa:system:serviceaccount:default:sa1",
+		"policy:customtype:virtualmachines",
+		keyPoliciesEnabled,
+	} {
+		if isMember, _ := c.client.SIsMember(ctx, k, policyKey).Result(); isMember {
+			t.Errorf("disabled policy still indexed under %s", k)
+		}
+	}
+}
+
+func TestStorePolicy_EffectChangeRemovesOldEffectSet(t *testing.T) {
+	c, _ := newTestClient(t)
+	ctx := t.Context()
+
+	p := testPolicy()
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	p.Effect = "Deny"
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	policyKey := "policy:default:test-policy"
+	if isMember, _ := c.client.SIsMember(ctx, "policies:effect:allow", policyKey).Result(); isMember {
+		t.Error("policy should not remain in policies:effect:allow after switching to Deny")
+	}
+	if isMember, _ := c.client.SIsMember(ctx, "policies:effect:deny", policyKey).Result(); !isMember {
+		t.Error("policy should be in policies:effect:deny after switching effect")
+	}
+}
+
+func TestInvalidateEvaluationCaches_GroupScansDecisionKeys(t *testing.T) {
+	c, _ := newTestClient(t)
+	ctx := t.Context()
+
+	// Seed cache entries for a few principals.
+	keysShouldGo := []string{
+		"rbac:decision:bob:eng,team:view:cluster:c1",
+		"rbac:custom:bob:eng,team:vms:c1:view",
+		// Group alone (single-group CSV).
+		"rbac:decision:carol:team:view:cluster:c1",
+	}
+	keysShouldStay := []string{
+		"rbac:decision:dave:other:view:cluster:c1",
+		"rbac:custom:dave:other:vms:c1:view",
+		// User with empty groups CSV — should be untouched by group invalidation.
+		"rbac:decision:erin::view:cluster:c1",
+		// Unrelated key shape.
+		"rbac:decision:other:noise:noise:noise",
+	}
+	for _, k := range append(append([]string{}, keysShouldGo...), keysShouldStay...) {
+		if err := c.client.Set(ctx, k, "x", 0).Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// No group:members:* key is set anywhere — fix should still find affected entries.
+	c.InvalidateEvaluationCaches(ctx, nil, []string{"team"}, nil)
+
+	for _, k := range keysShouldGo {
+		if exists, _ := c.client.Exists(ctx, k).Result(); exists != 0 {
+			t.Errorf("expected %s to be invalidated", k)
+		}
+	}
+	for _, k := range keysShouldStay {
+		if exists, _ := c.client.Exists(ctx, k).Result(); exists != 1 {
+			t.Errorf("expected %s to remain", k)
+		}
+	}
+}
+
+func TestStorePolicy_UpdateInvalidatesRemovedUserCache(t *testing.T) {
+	c, _ := newTestClient(t)
+	ctx := t.Context()
+
+	p := testPolicy()
+	p.Users = []string{"alice"}
+	p.Groups = nil
+	p.ServiceAccounts = nil
+	if err := c.StorePolicy(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed an "allow" decision for alice.
+	aliceKey := "rbac:decision:alice::view:cluster:c1"
+	c.client.Set(ctx, aliceKey, "x", 0)
+
+	// Re-store with alice removed.
+	p2 := testPolicy()
+	p2.Users = []string{"bob"}
+	p2.Groups = nil
+	p2.ServiceAccounts = nil
+	if err := c.StorePolicy(ctx, p2); err != nil {
+		t.Fatal(err)
+	}
+
+	// alice's stale "allow" decision must be cleared even though she's not in the new policy.
+	if exists, _ := c.client.Exists(ctx, aliceKey).Result(); exists != 0 {
+		t.Error("expected stale decision for removed user 'alice' to be invalidated on policy update")
+	}
+}
+
+func TestCacheKeyMatchesGroup(t *testing.T) {
+	changed := map[string]struct{}{"team": {}}
+	tests := []struct {
+		name   string
+		suffix string
+		want   bool
+	}{
+		{"empty groups csv", "bob::view:cluster:c1", false},
+		{"single group hit", "bob:team:view:cluster:c1", true},
+		{"multi-group hit", "bob:eng,team:view:cluster:c1", true},
+		{"miss", "bob:other:view:cluster:c1", false},
+		{"sa-style with colons in username", "system:serviceaccount:default:sa1::view:cluster:c1", false},
+		{"sa-style colliding with group name in middle segment", "system:team:default:sa1::view:cluster:c1", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cacheKeyMatchesGroup(tc.suffix, changed); got != tc.want {
+				t.Errorf("cacheKeyMatchesGroup(%q) = %v, want %v", tc.suffix, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiffAndUnionStrings(t *testing.T) {
+	t.Run("diff basic", func(t *testing.T) {
+		got := diffStrings([]string{"a", "b", "c"}, []string{"b"})
+		if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+			t.Errorf("diffStrings = %v", got)
+		}
+	})
+	t.Run("diff empty a", func(t *testing.T) {
+		if got := diffStrings(nil, []string{"x"}); got != nil {
+			t.Errorf("diffStrings(nil, ...) = %v, want nil", got)
+		}
+	})
+	t.Run("union dedupes", func(t *testing.T) {
+		got := unionStrings([]string{"a", "b"}, []string{"b", "c"})
+		set := map[string]struct{}{}
+		for _, s := range got {
+			set[s] = struct{}{}
+		}
+		if len(set) != 3 {
+			t.Errorf("unionStrings = %v (deduped set len = %d, want 3)", got, len(set))
+		}
+	})
+}
+
 func TestClearStaleEvalCaches(t *testing.T) {
 	c, _ := newTestClient(t)
 	ctx := t.Context()


### PR DESCRIPTION
- Diff old vs new compiled policy in StorePolicy so subject (user/groups/sa) removals actually clean their indexes.
- replace dead group:members:* lookup w/ SCAN over rbac:decision:* and rbac:custom:* 
- retry User.Get w/ X-Forwarded-Email when X-Forwarded-User 404s 
- cache resolveGroups in-memory